### PR TITLE
Laravel 5.2 compatibility

### DIFF
--- a/src/Setting.php
+++ b/src/Setting.php
@@ -222,7 +222,7 @@ class Setting {
         $constraint_query = $this->getConstraintQuery($constraint_value);
         $json = \DB::table($this->table)
             ->whereRaw($constraint_query)
-            ->pluck($this->column);
+            ->value($this->column);
 
         $this->settings[$constraint_value] = json_decode($json, true);
 


### PR DESCRIPTION
The Eloquent and query builder `pluck` method has been deprecated and renamed to `value`

See here: https://laravel.com/docs/master/upgrade
