### PR TITLE
Update 2015_01_20_105810_add_settings_to_users_table.php

### DIFF
--- a/migrations/2015_01_20_105810_add_settings_to_users_table.php
+++ b/migrations/2015_01_20_105810_add_settings_to_users_table.php
@@ -14,7 +14,7 @@ class AddSettingsToUsersTable extends Migration {
 	{
 		Schema::table('users', function(Blueprint $table)
 		{
-			$table->string('settings');
+			$table->text('settings');
 		});
 	}
 

--- a/migrations/2015_01_20_105810_add_settings_to_users_table.php
+++ b/migrations/2015_01_20_105810_add_settings_to_users_table.php
@@ -14,7 +14,7 @@ class AddSettingsToUsersTable extends Migration {
 	{
 		Schema::table('users', function(Blueprint $table)
 		{
-			$table->text('settings');
+			$table->json('settings');
 		});
 	}
 


### PR DESCRIPTION
Currently, the `SETTINGS`field in the database (or rather within the migration file) is declared as `STRING`. This, however, only allows for storing max. 255 chars (at least for MySQL databases). Keep in mind, that the settings are stored as JSON object (i.e., one need additional chars for braces, commas, ...).

It would be good to change the type of the settings field in the migration file to `TEXT` to store at least 65k chars!
#13
