### PR TITLE
switch from JSON to TEXT (MASTER)

### DIFF
--- a/migrations/2015_01_20_105810_add_settings_to_users_table.php
+++ b/migrations/2015_01_20_105810_add_settings_to_users_table.php
@@ -14,7 +14,7 @@ class AddSettingsToUsersTable extends Migration {
 	{
 		Schema::table('users', function(Blueprint $table)
 		{
-			$table->json('settings');
+			$table->text('settings');
 		});
 	}
 


### PR DESCRIPTION
because of backwards compatibility move back from JSON to TEXT.

See issue #16 
