### PR TITLE
Resolves issue with SQLite databases, and defaults

### DIFF
--- a/migrations/2015_01_20_105810_add_settings_to_users_table.php
+++ b/migrations/2015_01_20_105810_add_settings_to_users_table.php
@@ -14,7 +14,7 @@ class AddSettingsToUsersTable extends Migration {
 	{
 		Schema::table('users', function(Blueprint $table)
 		{
-			$table->text('settings');
+			$table->text('settings')->nullable();
 		});
 	}
 


### PR DESCRIPTION
Adding nullable() allows column to be added to SQLite tables.

SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL (SQL: alter table "users" add column "settings" text not null)  

SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL